### PR TITLE
[FIX] Add markdown dependency

### DIFF
--- a/15.0/requirements.txt
+++ b/15.0/requirements.txt
@@ -1,3 +1,4 @@
 redis==4.0.2
 graphene==3.0
 graphql-server==3.0.0b4
+markdown


### PR DESCRIPTION
With the https://github.com/odoogap/vuestorefront/commit/fe87baeb18d22417fc1edf27d30359bcde3fb1f9 change requirements were not updated.