### PR TITLE
ADD node middleware env

### DIFF
--- a/.env
+++ b/.env
@@ -4,6 +4,7 @@ NODE_LOCALE=en-EN
 BASE_URL=http://localhost:8069/
 BACKEND_BASE_URL=http://odoo:8069/
 SITE_URL=http://localhost:3000/
+NODE_API_BASE_URL=http://localhost:3000/api/
 INVALIDATION_KEY=change-me-to-a-long-key
 
 REDIS_ENABLED=true


### PR DESCRIPTION
Add node server url as doc says https://docs.vuestorefront.io/v2/security/api-url.html It fixes the session loss in vsf-odoo 1.5.0+